### PR TITLE
docs: use user namespace for links while experimental

### DIFF
--- a/cdn_definitions/schema.json
+++ b/cdn_definitions/schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://release-engineering.github.io/cdn-definitions/schema.json",
+    "$id": "http://rohanpm.github.io/cdn-definitions/schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {

--- a/cdn_definitions/schema.yaml
+++ b/cdn_definitions/schema.yaml
@@ -7,7 +7,7 @@
 # Check the dataset itself for explanatory comments on each field.
 
 $schema: http://json-schema.org/draft-07/schema#
-$id: http://release-engineering.github.io/cdn-definitions/schema.json
+$id: http://rohanpm.github.io/cdn-definitions/schema.json
 
 
 definitions:

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -8,8 +8,8 @@ This dataset contains the latest version of CDN definitions.
 
 It is also available in raw JSON or YAML format at URLs:
 
-- https://release-engineering.github.io/cdn-definitions/data.json
-- https://release-engineering.github.io/cdn-definitions/data.yaml
+- https://rohanpm.github.io/cdn-definitions/data.json
+- https://rohanpm.github.io/cdn-definitions/data.yaml
 
 
 .. include:: ../cdn_definitions/data.yaml
@@ -24,8 +24,8 @@ the CDN definitions.
 
 It is also available in raw JSON or YAML format at URLs:
 
-- https://release-engineering.github.io/cdn-definitions/schema.json
-- https://release-engineering.github.io/cdn-definitions/schema.yaml
+- https://rohanpm.github.io/cdn-definitions/schema.json
+- https://rohanpm.github.io/cdn-definitions/schema.yaml
 
 .. include:: ../cdn_definitions/schema.yaml
     :code: yaml

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -7,8 +7,8 @@ Usage as online dataset
 
 The latest version of this dataset can be downloaded at any time from URLs:
 
-- https://release-engineering.github.io/cdn-definitions/data.json
-- https://release-engineering.github.io/cdn-definitions/data.yaml
+- https://rohanpm.github.io/cdn-definitions/data.json
+- https://rohanpm.github.io/cdn-definitions/data.yaml
 
 Both files contain equivalent data.
 


### PR DESCRIPTION
This is ultimately expected to be hosted under release-engineering,
but let's not use those URLs until that happens, since links are
all broken otherwise.